### PR TITLE
0x00 EQ to ISZERO and documentation fixes

### DIFF
--- a/src/protocol/TSender.huff
+++ b/src/protocol/TSender.huff
@@ -128,7 +128,7 @@
         dup2 dup1                                                                                               // [address_offset, address_offset, diff, address_offset, end, diff, token_address, total_amount]  
         calldataload                                                                                            // [to_address, address_offset, address_offset, diff, address_offset, end, diff, token_address, total_amount]  
         // zero address check
-        dup1 0x00 eq zero_address_to jumpi                                                                      // [to_address, address_offset, address_offset, diff, address_offset, end, diff, token_address, total_amount]  
+        dup1 iszero zero_address_to jumpi                                                                      // [to_address, address_offset, address_offset, diff, address_offset, end, diff, token_address, total_amount]  
         // Store to address in memory
         [TO_ADDRESS_MEMORY_LOCATION] mstore                                                                     // [address_offset, diff, address_offset, end, diff, token_address, total_amount]     
         // Store amount in memory

--- a/src/protocol/TSender.huff
+++ b/src/protocol/TSender.huff
@@ -119,16 +119,16 @@
     // recipients.length
     [NUMBER_OF_RECIPIENTS_OFFSET] calldataload 
     // add(recipients.offset, shl(5
-    0x5 shl [RECIPIENT_ONE_OFFSET] add                                                     // [end, address_offset, diff, token_address, total_amount]
+    0x5 shl [RECIPIENT_ONE_OFFSET] add                                                     // [end, diff, token_address, total_amount]
     [RECIPIENT_ONE_OFFSET]                                                                 // [address_offset, end, diff, token_address, total_amount]
     
     loop_start:
         dup3                                                                               // [diff, address_offset, end, diff, token_address, total_amount]   
         // To address, and setting up to use addressOffset later
         dup2 dup1                                                                                               // [address_offset, address_offset, diff, address_offset, end, diff, token_address, total_amount]  
-        calldataload                                                                                            // [to_address, address_offset, address_offset, diff, address_offset, end, diff, token_address, total_amount]  
+        calldataload                                                                                            // [to_address, address_offset, diff, address_offset, end, diff, token_address, total_amount]  
         // zero address check
-        dup1 iszero zero_address_to jumpi                                                                      // [to_address, address_offset, address_offset, diff, address_offset, end, diff, token_address, total_amount]  
+        dup1 iszero zero_address_to jumpi                                                                       // [to_address, address_offset, diff, address_offset, end, diff, token_address, total_amount]  
         // Store to address in memory
         [TO_ADDRESS_MEMORY_LOCATION] mstore                                                                     // [address_offset, diff, address_offset, end, diff, token_address, total_amount]     
         // Store amount in memory

--- a/src/protocol/TSender.sol
+++ b/src/protocol/TSender.sol
@@ -63,13 +63,17 @@ contract TSender {
             // transfer(address to, uint256 value)
             mstore(0x00, hex"a9059cbb")
             // end of array
-            // recipients.offset actually points to the recipients.length offset, not the first address of the array offset
+            // recipients.offset points to the first address of the array
             let end := add(recipients.offset, shl(5, recipients.length))
             let diff := sub(recipients.offset, amounts.offset)
 
             // Checking totals at the end
             let addedAmount := 0
-            for { let addressOffset := recipients.offset } 1 {} {
+            for {
+                let addressOffset := recipients.offset
+            } 1 {
+
+            } {
                 let recipient := calldataload(addressOffset)
 
                 // Check to address
@@ -80,6 +84,7 @@ contract TSender {
 
                 // to address
                 mstore(0x04, recipient)
+
                 // amount
                 mstore(0x24, calldataload(sub(addressOffset, diff)))
                 // Keep track of the total amount
@@ -94,7 +99,9 @@ contract TSender {
                 // increment the address offset
                 addressOffset := add(addressOffset, 0x20)
                 // if addressOffset >= end, break
-                if iszero(lt(addressOffset, end)) { break }
+                if iszero(lt(addressOffset, end)) {
+                    break
+                }
             }
 
             // Check if the totals match
@@ -118,7 +125,10 @@ contract TSender {
      * @param amounts The list of amounts to check
      * @return bool
      */
-    function areListsValid(address[] calldata recipients, uint256[] calldata amounts) external pure returns (bool) {
+    function areListsValid(
+        address[] calldata recipients,
+        uint256[] calldata amounts
+    ) external pure returns (bool) {
         if (recipients.length == 0) {
             return false;
         }


### PR DESCRIPTION
Little improvement (~2500 gas for 1000 recipients) changing `0x00 eq` with `iszero` in `TSender.sol`.
Some comments was describing the stack but with error in it. 
I’ve only proofread `TSender.huff::airdropERC20` and ``TSender.sol::airdropERC20` for the comments.